### PR TITLE
Minor bug

### DIFF
--- a/socks/socks.go
+++ b/socks/socks.go
@@ -55,8 +55,8 @@ func (a Addr) String() string {
 
 	switch a[0] { // address type
 	case AtypDomainName:
-		host = string(a[2 : 2+a[1]])
-		port = strconv.Itoa((int(a[2+a[1]]) << 8) | int(a[2+a[1]+1]))
+		host = string(a[2 : 2+int(a[1])])
+		port = strconv.Itoa((int(a[2+int(a[1])]) << 8) | int(a[2+int(a[1])+1]))
 	case AtypIPv4:
 		host = net.IP(a[1 : 1+net.IPv4len]).String()
 		port = strconv.Itoa((int(a[1+net.IPv4len]) << 8) | int(a[1+net.IPv4len+1]))
@@ -82,8 +82,8 @@ func ReadAddr(r io.Reader) (Addr, error) {
 		if err != nil {
 			return nil, err
 		}
-		_, err = io.ReadFull(r, b[2:2+b[1]+2])
-		return b[:1+1+b[1]+2], err
+		_, err = io.ReadFull(r, b[2:2+int(b[1])+2])
+		return b[:1+1+int(b[1])+2], err
 	case AtypIPv4:
 		_, err = io.ReadFull(r, b[1:1+net.IPv4len+2])
 		return b[:1+net.IPv4len+2], err


### PR DESCRIPTION
But it causes runtime panic when indexing specific size domain name

`panic: runtime error: slice bounds out of range

goroutine 2026854 [running]:
github.com/shadowsocks/go-shadowsocks2/socks.ReadAddr(0x7f3db541df80, 0xc429c676e0, 0xc429c676e0, 0x7f3db541df80, 0xc429c676e0, 0x0, 0xc420021f30)`