### PR TITLE
fixed #78

### DIFF
--- a/socks/socks.go
+++ b/socks/socks.go
@@ -188,11 +188,12 @@ func Handshake(rw io.ReadWriter) (Addr, error) {
 	if _, err := io.ReadFull(rw, buf[:3]); err != nil {
 		return nil, err
 	}
+	buf1 := buf[1]
 	addr, err := readAddr(rw, buf)
 	if err != nil {
 		return nil, err
 	}
-	switch buf[1] {
+	switch buf1 {
 	case CmdConnect:
 		_, err = rw.Write([]byte{5, 0, 0, 1, 0, 0, 0, 0, 0, 0}) // SOCKS v5, reply succeeded
 	case CmdUDPAssociate:


### PR DESCRIPTION
https://github.com/shadowsocks/go-shadowsocks2/blob/master/socks/socks.go#L191
这一个方法内部会修改`buf[1]`的值，导致作为客户端的时候报`failed to get target address: SOCKS error: 7` 的错误