### PR TITLE
Fix losing number of line when wrap the log function

### DIFF
--- a/main.go
+++ b/main.go
@@ -23,9 +23,11 @@ var config struct {
 	UDPTimeout time.Duration
 }
 
+var logger = log.New(os.Stderr, "", log.Lshortfile|log.LstdFlags)
+
 func logf(f string, v ...interface{}) {
 	if config.Verbose {
-		log.Printf(f, v...)
+		logger.Output(2, fmt.Sprintf(f, v...))
 	}
 }
 


### PR DESCRIPTION
Fixed the line number, easy to debug now.

![image](https://user-images.githubusercontent.com/371475/42018804-3395a048-7aee-11e8-951a-453f651e663c.png)
