### PR TITLE
Fix the overlap problem of udp decryption.

### DIFF
--- a/shadowaead/packet.go
+++ b/shadowaead/packet.go
@@ -88,6 +88,10 @@ func (c *packetConn) ReadFrom(b []byte) (int, net.Addr, error) {
 	if err != nil {
 		return n, addr, err
 	}
-	b, err = Unpack(b, b[:n], c)
-	return len(b), addr, err
+	bb, err := Unpack(b[c.Cipher.SaltSize():], b[:n], c)
+	if err != nil {
+		return n, addr, err
+	}
+	copy(b, bb)
+	return len(bb), addr, err
 }

--- a/shadowstream/packet.go
+++ b/shadowstream/packet.go
@@ -76,5 +76,5 @@ func (c *packetConn) ReadFrom(b []byte) (int, net.Addr, error) {
 		return n, addr, err
 	}
 	copy(b, bb)
-	return len(b), addr, err
+	return len(bb), addr, err
 }


### PR DESCRIPTION
Fix the issue described in https://github.com/shadowsocks/go-shadowsocks2/issues/95
Now return the correct length of data read by ReadFrom.