### PR TITLE
Backward compatibility support for chacha20

### DIFF
--- a/core/cipher.go
+++ b/core/cipher.go
@@ -56,6 +56,7 @@ var streamList = map[string]struct {
 	"AES-128-CFB":   {16, shadowstream.AESCFB},
 	"AES-192-CFB":   {24, shadowstream.AESCFB},
 	"AES-256-CFB":   {32, shadowstream.AESCFB},
+	"CHACHA20":      {32, shadowstream.Chacha20},
 	"CHACHA20-IETF": {32, shadowstream.Chacha20IETF},
 	"XCHACHA20":     {32, shadowstream.Xchacha20},
 }

--- a/shadowstream/cipher.go
+++ b/shadowstream/cipher.go
@@ -52,6 +52,28 @@ func AESCFB(key []byte) (Cipher, error) {
 	return &cfbStream{blk}, nil
 }
 
+// chacha20 with 8-bit nonce. Deprecated.
+//
+// Potential security hazard, see: https://github.com/shadowsocks/shadowsocks-org/issues/36#issuecomment-277496869
+type chacha20key []byte
+
+func (k chacha20key) IVSize() int                       { return chacha.NonceSize }
+func (k chacha20key) Decrypter(iv []byte) cipher.Stream { return k.Encrypter(iv) }
+func (k chacha20key) Encrypter(iv []byte) cipher.Stream {
+	ciph, err := chacha20.NewCipher(iv, k)
+	if err != nil {
+		panic(err) // should never happen
+	}
+	return ciph
+}
+
+func Chacha20(key []byte) (Cipher, error) {
+	if len(key) != chacha.KeySize {
+		return nil, KeySizeError(chacha.KeySize)
+	}
+	return chacha20key(key), nil
+}
+
 // IETF-variant of chacha20
 type chacha20ietfkey []byte
 


### PR DESCRIPTION
Although chacha20 with 8-bit nonce is deprecated for security reasons (as described by @riobard  in this thread https://github.com/shadowsocks/shadowsocks-org/issues/36#issuecomment-277496869), some production environments are still running chacha20.

Would you consider this PR if we add deprecation warnings if chacha20 is selected?