### PR TITLE
升级 Dockerfile 到 golang 1.12.4 alpine:3.9，增加 docker-compose 

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,6 @@
+.git
+.travis.yml
+go-shadowsocks2
+docker-compose.yaml
+vendor
+go.sum

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
 bin/
+.idea/
+vendor/
+go.sum

--- a/defaultstart.sh
+++ b/defaultstart.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+echo "Starting Shadowsocks Server..."
+echo "Use Method: ${SS_METHOD}; Password:${SS_PASSWORD}"
+shadowsocks -s ss://${SS_METHOD}:${SS_PASSWORD}@:8080 -verbose

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,15 @@
+version: '2'
+
+services:
+  shadowsocks2:
+    image: shadowsocks2:latest # need loaded the images
+    container_name: shadowsocks2
+    restart: always
+    environment:
+      - SS_PASSWORD=password
+      - SS_METHOD=aes-256-cfb
+#    volumes:
+#      - ./defaultstart.sh:/shadowsocks2/start.sh # override the defaultstart.sh
+    command: shadowsocks2 -s ss://aes-256-cfb:password@:8080 -verbose # empty start.sh and command
+    ports:
+      - "8080:8080"

--- a/go.mod
+++ b/go.mod
@@ -6,3 +6,12 @@ require (
 	github.com/aead/chacha20 v0.0.0-20180709150244-8b13a72661da
 	golang.org/x/crypto v0.0.0-20190426145343-a29dc8fdc734
 )
+
+replace (
+	golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2 => github.com/golang/crypto v0.0.0-20190308221718-c2843e01d9a2
+	golang.org/x/crypto v0.0.0-20190426145343-a29dc8fdc734 => github.com/golang/crypto v0.0.0-20190426145343-a29dc8fdc734
+	golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3 => github.com/golang/net v0.0.0-20190404232315-eb5bcb51f2a3
+	golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a => github.com/golang/sys v0.0.0-20190215142949-d0b11bdaac8a
+	golang.org/x/sys v0.0.0-20190412213103-97732733099d => github.com/golang/sys v0.0.0-20190412213103-97732733099d
+	golang.org/x/text v0.3.0 => github.com/golang/text v0.3.0
+)


### PR DESCRIPTION
1. 在 go.mod 文件中增加 ‘replace’ 指令来适应中国无法直接访问 golang.org 
2. 升级 Dockerfile 基于 golang 1.12.4 alpine:3.9
3. 修改 Dockerfile 基于本地代码编译 docker 镜像，增加运行脚本 start.sh，之后可以配合 docker-compose 覆盖该脚本来实现自定义启动脚本。
4.增加 docker-compose.yaml 文件，使用 docker-compose -f docker-compose.yaml up 来启动容器
5: 修改 .gitignore 增加 go.sum 