### PR TITLE
Write salt/iv, addr together with content

### DIFF
--- a/core/stream.go
+++ b/core/stream.go
@@ -4,6 +4,9 @@ import (
 	"bytes"
 	"io"
 	"net"
+	"sync"
+	"sync/atomic"
+	"time"
 
 	"github.com/shadowsocks/go-shadowsocks2/socks"
 )
@@ -31,12 +34,25 @@ func Dial(network, address string, ciph StreamConnCipher) (net.Conn, error) {
 // Connect sends the shadowsocks standard header to underlying ciphered connection
 // in the next Write/ReadFrom call.
 func Connect(c net.Conn, addr socks.Addr) net.Conn {
-	return &ssconn{Conn: c, addr: addr}
+	return newSSConn(c, addr, 5 * time.Millisecond)
 }
 
 type ssconn struct {
 	net.Conn
 	addr socks.Addr
+	done uint32
+	m    sync.Mutex
+	t    *time.Timer
+}
+
+func newSSConn(c net.Conn, addr socks.Addr, delay time.Duration) *ssconn {
+	sc := &ssconn{Conn: c, addr: addr}
+	if delay > 0 {
+		sc.t = time.AfterFunc(delay, func() {
+			sc.Write([]byte{})
+		})
+	}
+	return sc
 }
 
 func (c *ssconn) Write(b []byte) (int, error) {
@@ -45,9 +61,22 @@ func (c *ssconn) Write(b []byte) (int, error) {
 }
 
 func (c *ssconn) ReadFrom(r io.Reader) (int64, error) {
-	if len(c.addr) > 0 {
-		r = &readerWithAddr{Reader: r, b: c.addr}
-		c.addr = nil
+	if atomic.LoadUint32(&c.done) == 0 {
+		c.m.Lock()
+		defer c.m.Unlock()
+		if c.done == 0 {
+			defer atomic.StoreUint32(&c.done, 1)
+			if c.t != nil {
+				c.t.Stop()
+				c.t = nil
+			}
+			ra := readerWithAddr{Reader: r, b: c.addr}
+			n, err := io.Copy(c.Conn, &ra)
+			n -= int64(len(c.addr))
+			if n < 0 { n = 0 }
+			c.addr = nil
+			return n, err
+		}
 	}
 	return io.Copy(c.Conn, r)
 }
@@ -63,11 +92,10 @@ type readerWithAddr struct {
 
 func (r *readerWithAddr) Read(b []byte) (n int, err error) {
 	nc := copy(b, r.b)
-	if nc < len(r.b) {
-		r.b = r.b[:nc]
+	r.b = r.b[nc:]
+	if len(b) == nc {
 		return nc, nil
 	}
-	r.b = nil
 	nr, err := r.Reader.Read(b[nc:])
 	return nc + nr, err
 }

--- a/core/stream.go
+++ b/core/stream.go
@@ -1,6 +1,12 @@
 package core
 
-import "net"
+import (
+	"bytes"
+	"io"
+	"net"
+
+	"github.com/shadowsocks/go-shadowsocks2/socks"
+)
 
 type listener struct {
 	net.Listener
@@ -20,4 +26,48 @@ func (l *listener) Accept() (net.Conn, error) {
 func Dial(network, address string, ciph StreamConnCipher) (net.Conn, error) {
 	c, err := net.Dial(network, address)
 	return ciph.StreamConn(c), err
+}
+
+// Connect sends the shadowsocks standard header to underlying ciphered connection
+// in the next Write/ReadFrom call.
+func Connect(c net.Conn, addr socks.Addr) net.Conn {
+	return &ssconn{Conn: c, addr: addr}
+}
+
+type ssconn struct {
+	net.Conn
+	addr socks.Addr
+}
+
+func (c *ssconn) Write(b []byte) (int, error) {
+	n, err := c.ReadFrom(bytes.NewBuffer(b))
+	return int(n), err
+}
+
+func (c *ssconn) ReadFrom(r io.Reader) (int64, error) {
+	if len(c.addr) > 0 {
+		r = &readerWithAddr{Reader: r, b: c.addr}
+		c.addr = nil
+	}
+	return io.Copy(c.Conn, r)
+}
+
+func (c *ssconn) WriteTo(w io.Writer) (int64, error) {
+	return io.Copy(w, c.Conn)
+}
+
+type readerWithAddr struct {
+	io.Reader
+	b []byte
+}
+
+func (r *readerWithAddr) Read(b []byte) (n int, err error) {
+	nc := copy(b, r.b)
+	if nc < len(r.b) {
+		r.b = r.b[:nc]
+		return nc, nil
+	}
+	r.b = nil
+	nr, err := r.Reader.Read(b[nc:])
+	return nc + nr, err
 }


### PR DESCRIPTION
Sending salt, address and content seperately would generate three packets during the start of a connection. Since the size of salt is almost always 8, 16 or 32 and the address are pretty much always 20-100 bytes, it leaves a strong feature.

Additionally, with TCP fastopen turned on, only the first write would be carried by
SYN packet. The other writes will have to wait until the handshake complete, making fastopen pointless.