### PR TITLE
Fix a race condition that could allow same Salt/IV to be reused

### DIFF
--- a/internal/bloomring.go
+++ b/internal/bloomring.go
@@ -46,6 +46,10 @@ func (r *BloomRing) Add(b []byte) {
 	}
 	r.mutex.Lock()
 	defer r.mutex.Unlock()
+	r.add(b)
+}
+
+func (r *BloomRing) add(b []byte) {
 	slot := r.slots[r.slotPosition]
 	if r.entryCounter > r.slotCapacity {
 		// Move to next slot and reset
@@ -64,10 +68,25 @@ func (r *BloomRing) Test(b []byte) bool {
 	}
 	r.mutex.RLock()
 	defer r.mutex.RUnlock()
+	test := r.test(b)
+	return test
+}
+
+func (r *BloomRing) test(b []byte) bool {
 	for _, s := range r.slots {
 		if s.Test(b) {
 			return true
 		}
 	}
+	return false
+}
+
+func (r *BloomRing) Check(b []byte) bool {
+	r.mutex.Lock()
+	defer r.mutex.Unlock()
+	if r.Test(b) {
+		return true
+	}
+	r.Add(b)
 	return false
 }

--- a/internal/saltfilter.go
+++ b/internal/saltfilter.go
@@ -79,3 +79,7 @@ func TestSalt(b []byte) bool {
 func AddSalt(b []byte) {
 	getSaltFilterSingleton().Add(b)
 }
+
+func CheckSalt(b []byte) bool {
+	return getSaltFilterSingleton().Test(b)
+}

--- a/shadowaead/packet.go
+++ b/shadowaead/packet.go
@@ -46,14 +46,13 @@ func Unpack(dst, pkt []byte, ciph Cipher) ([]byte, error) {
 		return nil, ErrShortPacket
 	}
 	salt := pkt[:saltSize]
-	if internal.TestSalt(salt) {
-		return nil, ErrRepeatedSalt
-	}
 	aead, err := ciph.Decrypter(salt)
 	if err != nil {
 		return nil, err
 	}
-	internal.AddSalt(salt)
+	if internal.CheckSalt(salt) {
+		return nil, ErrRepeatedSalt
+	}
 	if len(pkt) < saltSize+aead.Overhead() {
 		return nil, ErrShortPacket
 	}

--- a/shadowaead/stream.go
+++ b/shadowaead/stream.go
@@ -205,14 +205,14 @@ func (c *streamConn) initReader() error {
 	if _, err := io.ReadFull(c.Conn, salt); err != nil {
 		return err
 	}
-	if internal.TestSalt(salt) {
-		return ErrRepeatedSalt
-	}
 	aead, err := c.Decrypter(salt)
 	if err != nil {
 		return err
 	}
-	internal.AddSalt(salt)
+
+	if internal.CheckSalt(salt) {
+		return ErrRepeatedSalt
+	}
 
 	c.r = newReader(c.Conn, aead)
 	return nil


### PR DESCRIPTION
If the attacker have precise timing, it could be possible for it to trick ss into accept multiple connection with the same Salt/IV if they all pass the Salt/iv test at the same time if while other connection c.Encrypter(salt) is in process, and before they add that IV into the anti-replay pool.

This PR does not solve any protocol weakness.