### PR TITLE
Add linux-tgz release file

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,6 +41,7 @@ test-win32:
 
 releases: linux macos-amd64 macos-arm64 win64 win32
 	chmod +x $(BINDIR)/$(NAME)-*
+	tar czf $(BINDIR)/$(NAME)-linux.tgz -C $(BINDIR) $(NAME)-linux
 	gzip $(BINDIR)/$(NAME)-linux
 	gzip $(BINDIR)/$(NAME)-macos-amd64
 	gzip $(BINDIR)/$(NAME)-macos-arm64
@@ -54,6 +55,7 @@ clean:
 GITHUB_UPLOAD_URL=$(shell echo $${GITHUB_RELEASE_UPLOAD_URL%\{*})
 
 upload: releases
+	curl -H "Authorization: token $(GITHUB_TOKEN)" -H "Content-Type: application/gzip" --data-binary @$(BINDIR)/$(NAME)-linux.tgz  "$(GITHUB_UPLOAD_URL)?name=$(NAME)-linux.tgz"
 	curl -H "Authorization: token $(GITHUB_TOKEN)" -H "Content-Type: application/gzip" --data-binary @$(BINDIR)/$(NAME)-linux.gz  "$(GITHUB_UPLOAD_URL)?name=$(NAME)-linux.gz"
 	curl -H "Authorization: token $(GITHUB_TOKEN)" -H "Content-Type: application/gzip" --data-binary @$(BINDIR)/$(NAME)-macos-amd64.gz  "$(GITHUB_UPLOAD_URL)?name=$(NAME)-macos-amd64.gz"
 	curl -H "Authorization: token $(GITHUB_TOKEN)" -H "Content-Type: application/gzip" --data-binary @$(BINDIR)/$(NAME)-macos-arm64.gz  "$(GITHUB_UPLOAD_URL)?name=$(NAME)-macos-arm64.gz"


### PR DESCRIPTION
add a linx tgz(tar.gz) release file that can use by `Ansible Unarchive`
ansible-playbook like:
```
  - name: Download & Unarchive go-shadowsocks2
    unarchive:
      remote_src: yes
      src: https://github.com/shadowsocks/go-shadowsocks2/releases/download/{{ version }}/shadowsocks2-linux.tgz
      dest: /usr/bin

  - name: Copy & Add go-shadowsocks2 systemd  service
    copy:
      src: go-shadowsocks2.service
      dest: /lib/systemd/system/go-shadowsocks2.service

  - name: Start & Enable go-shadowsocks2 service
    systemd:
      name: go-shadowsocks2
      state: started
      enabled: yes
      daemon_reload: yes
```
file go-shadowsocks2.service like:
```
[Unit]
Description=Shadowsocks2
Wants=network-online.target
After=network-online.target

[Service]
User=nobody
PermissionsStartOnly=true
ExecStart=/usr/bin/shadowsocks2-linux -s 'ss://AEAD_CHACHA20_POLY1305:1234@:5678'
Nice=-10
KillMode=process
Restart=on-failure
ProtectSystem=full
ProtectHome=true
PrivateTmp=true
PrivateDevices=true
NoNewPrivileges=true

[Install]
WantedBy=multi-user.target%
```