### PR TITLE
Cross-compile by GoReleaser

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,16 +1,65 @@
 name: Build and release
 on: 
-  release:
-    types: [published]
+  workflow_dispatch:
+    inputs:
+      upx_version:
+        description: 'UPX version'
+        required: true
+        default: '3.96'
+
 jobs:
-  build:
-    runs-on: ubuntu-latest
+  release:
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 30
+    strategy:
+      matrix:
+        go: ["1.17.x"]
+        os: [ubuntu-latest]
+    name: Go ${{ matrix.go }} in ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v2
         with:
-          go-version: 1.16
-      - run: make -j upload
+          go-version: ${{ matrix.go }}
+      - name: Environment
+        run: |
+          go version
+          go env
+          
+      # So GoReleaser can generate the changelog properly
+      - name: Unshallowify the repo clone
+        run: git fetch --prune --unshallow
+        
+      - name: Check git tag exist
+        run: |
+          git fetch --depth=1 origin +refs/tags/*:refs/tags/*
+          gitTagExists=$(git tag --points-at HEAD)
+          if ! [ -n "$gitTagExists" ]; then
+              echo "no tag, create one."
+              latesttag=$(git describe --tags `git rev-list --tags --max-count=1`)
+              echo "latest tag: ${latesttag}"
+              newtag=$(echo ${latesttag} | awk -F. -v OFS=. 'NF==1{print ++$NF}; NF>1{if(length($NF+1)>length($NF))$(NF-1)++; $NF=sprintf("%0*d", length($NF), ($NF+1)%(10^length($NF))); print}')
+              echo "new tag: ${newtag}"
+              git tag $newtag
+          fi
+      
+      - name: Installing upx
+        env:
+          UPX_VERSION: ${{ github.event.inputs.upx_version }}
+        run: |
+          echo "Installing upx .."
+          curl -OL "https://github.com/upx/upx/releases/download/v${UPX_VERSION}/upx-${UPX_VERSION}-amd64_linux.tar.xz"
+          tar xvf "upx-${UPX_VERSION}-amd64_linux.tar.xz"
+          cp "upx-${UPX_VERSION}-amd64_linux/upx" "$(go env GOPATH)/bin"
+          upx --version
+          
+      - name: Run Test
+        run: make -j test
+        
+      - name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@v2
+        with:
+          version: latest
+          args: release --rm-dist --skip-validate --skip-sign --debug
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          GITHUB_RELEASE_UPLOAD_URL: ${{ github.event.release.upload_url }}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,0 +1,109 @@
+env:
+  - GO111MODULE=on
+
+builds:
+  - id: upx
+    env:
+      - CGO_ENABLED=0
+    ldflags:
+      - "-s -w"
+    goos:
+      - windows
+      - darwin
+      - linux
+    goarch:
+      - 386
+      - amd64
+      - arm
+      - arm64
+      - mips
+      - mipsle
+    goarm:
+      - 5
+      - 6
+      - 7
+    gomips:
+      - hardfloat
+      - softfloat
+    ignore:
+      - goos: darwin
+        goarch: 386
+      - goos: windows
+        goarch: arm
+      - goos: windows
+        goarch: arm64
+    hooks:
+      post:
+        - upx "{{ .Path }}"
+  - id: noupx-freebsd
+    env:
+      - CGO_ENABLED=0
+    ldflags:
+      - -w -s
+    goos:
+      - freebsd
+    goarch:
+      - 386
+      - amd64
+      - arm
+      - arm64
+      - mips
+      - mipsle
+    goarm:
+      - 5
+      - 6
+      - 7
+    gomips:
+      - hardfloat
+      - softfloat
+  - id: noupx-linux-mips64
+    env:
+      - CGO_ENABLED=0
+    ldflags:
+      - -w -s
+    goos:
+      - linux
+    goarch:
+      - mips64
+      - mips64le
+    gomips:
+      - hardfloat
+      - softfloat
+  - id: noupx-windows-arm
+    env:
+      - CGO_ENABLED=0
+    ldflags:
+      - -w -s
+    goos:
+      - windows
+    goarch:
+      - arm
+      - arm64
+    goarm:
+      - 5
+      - 6
+      - 7
+archives:
+  - name_template: "{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}{{ if .Arm }}_v{{ .Arm }}{{ end }}{{ if .Mips }}_{{ .Mips }}{{ end }}"
+    format: tar.gz
+    files:
+      - none*
+    format_overrides:
+      - goos: windows
+        format: zip
+    wrap_in_directory: false
+    replacements:
+      amd64: 64-bit
+      386: 32-bit
+      arm: ARM
+      arm64: ARM64
+      darwin: macOS
+      linux: Linux
+      windows: Windows
+      openbsd: OpenBSD
+      netbsd: NetBSD
+      freebsd: FreeBSD
+release:
+  draft: true
+  prerelease: auto
+  name_template: "{{.ProjectName}}-v{{.Version}}-{{.Date}}"


### PR DESCRIPTION
Enhance the cross-compile and output more platform binary

- Need to trigger the action manully
- Can add new tag automatically
- Use [upx](https://github.com/upx/upx) to compress the output binary

Here is a output result: https://github.com/cxjava/go-shadowsocks2/releases/tag/v0.1.6