### PR TITLE
Use the new go install syntax in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Pre-built binaries for common platforms are available at https://github.com/shad
 Install from source
 
 ```sh
-go get -u -v github.com/shadowsocks/go-shadowsocks2
+go install -u github.com/shadowsocks/go-shadowsocks2@latest
 ```
 
 


### PR DESCRIPTION
Since a while ago, go no longer supports use of `go get` to install binaries. Use the new `go install` command for the README instead!